### PR TITLE
Edits to R packages slides

### DIFF
--- a/slides/02_r_packages.qmd
+++ b/slides/02_r_packages.qmd
@@ -72,7 +72,7 @@ Nowadays, it's super fast with:
   - Check CRAN to see if your name is available
 - *Title*: Add a Title for Your Package (Title Case)
 - *Version*: Start with a low package version
-  - `Major.Minor.Patch` syntax
+  - `Major.Minor.Patch` syntax ([Semantic Versioning](https://semver.org/))
 - *Authors@R*: Add authors and maintainer
 - *Description*: Like an abstract, including references
 
@@ -351,12 +351,14 @@ readr::read_csv(here::here("slides/resources/keyboard-shortcuts.csv"), col_types
 
 1. Set up a new R package with a fancy name
 1. Fill out the `DESCRIPTION` file
-1. Include a new function
+1. Include a few functions
 1. Add `roxygen2` documentation
 1. Export the function to the namespace
 1. Produce the package documentation
 1. Run checks
 1. Build the package
+
+> We will be using this package throughout the day!
 
 # References
 


### PR DESCRIPTION
Minor edits to R packages slides:

1. Added an explicit reference to semantic versioning
2. Slightly updated the practical to emphasise that we are going to use the example package throughout the day